### PR TITLE
BREAKING CHANGE: Require Rollup 1.0+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,21 @@
 'use strict'
 
-var fs = require('fs')
-var path = require('path')
-var rimraf = require('rimraf')
+const { promisify } = require('util')
+const fs = require('fs')
+const path = require('path')
+const rimraf = promisify(require('rimraf'))
 
-module.exports = function(options) {
-  options = options || {}
-  var targets = options.targets ? options.targets : []
-  var silent = options.silent === true
+module.exports = function({ targets = [], silent = true } = {}) {
   return {
     name: 'cleaner',
-    ongenerate: function(details) {
-      var normalisedPath
-      if (targets && targets.length) {
-        for (let i = 0; i < targets.length; i++) {
-          normalisedPath = path.normalize(targets[i])
-          if (fs.existsSync(normalisedPath)) {
-            !silent && console.log('cleaning path: ' + normalisedPath)
-            rimraf.sync(normalisedPath)
+    async buildStart(options) {
+      for (const targetPath of targets) {
+        const normalisedPath = path.normalize(targetPath)
+        if (fs.existsSync(normalisedPath)) {
+          if (!silent) {
+            console.log(`cleaning path: ${normalisedPath}`)
           }
+          await rimraf(normalisedPath)
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -29,9 +29,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -51,9 +51,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -83,18 +83,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
-    },
-    "rollup": {
-      "version": "0.52.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.3.tgz",
-      "integrity": "sha512-cw+vb9NqaTXlwJyb8G+Ve+uhhlVTcl1NKBkfANdeQqVcpZFilQgeNnAnNiu7MwfeXrqiKEGz+3R03a3zeFkmEQ==",
-      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "A rollup plugin to clean directories before rebuilding.",
   "main": "index.js",
-  "repository": "https://github.com/saf33r/rollup-plugin-cleaner.git",
+  "repository": "saf33r/rollup-plugin-cleaner",
   "bugs": "https://github.com/saf33r/rollup-plugin-cleaner/issues",
   "author": "Safeer Ahmed",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "test": "npm run prettier:check"
   },
   "devDependencies": {
-    "prettier": "^1.18.2",
-    "rollup": "^0.52.1"
+    "prettier": "^1.18.2"
+  },
+  "peerDependencies": {
+    "rollup": "> 1.0"
   },
   "dependencies": {
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.3"
+  },
+  "engines": {
+    "node": ">= 8.0"
   }
 }


### PR DESCRIPTION
- Use Rollup 1.0 plugin API.
- Run the hook synchronously.
- Remove unused dependencies.
- Declare peer and engine dependency.